### PR TITLE
Prevent side scroll on frontpage

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -104,6 +104,10 @@
   color: var(--bouvet-beige);
 }
 
+.main-wrapper {
+  overflow: hidden;
+}
+
 .row {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
The `.dev-ops-links-backdrop` element causes a really large horizontal scroll on the front page.